### PR TITLE
Add text substitutions on Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   "config": {
     "serviceURL": "https://web.whatsapp.com",
     "hasNotificationSound": true
+  },
+  "dependencies": {
+    "electron-text-substitutions": "^1.4.16"
   }
 }

--- a/webview.js
+++ b/webview.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const performTextSubstitutions = require('electron-text-substitutions').default;
 
 module.exports = (Franz) => {
   const getMessages = function getMessages() {
@@ -15,9 +16,23 @@ module.exports = (Franz) => {
     Franz.setBadge(count);
   };
 
+  this.lastTextInput = null;
+
+  const attachTextSubstitutions = function attachTextSubstitutions() {
+    const textInput = document.querySelector('.copyable-text.selectable-text[contenteditable="true"]');
+
+    if (textInput && !this.lastTextInput !== textInput) {
+      performTextSubstitutions(textInput);
+      this.lastTextInput = textInput;
+    }
+  };
+
   // inject franz.css stylesheet
   Franz.injectCSS(path.join(__dirname, 'service.css'));
 
   // check for new messages every second and update Franz badge
   Franz.loop(getMessages);
+
+  // check for new text input to attach text substitutions
+  Franz.loop(attachTextSubstitutions);
 };


### PR DESCRIPTION
This PR adds the feature to perform text substitutions on Mac, relying on `electron-text-substitutions` package.