### PR TITLE
Identify unread messages with more reability

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -1,30 +1,31 @@
-const { remote } = require('electron');
+"use strict";
+
+const {
+  remote
+} = require('electron');
+
 const path = require('path');
 
 const webContents = remote.getCurrentWebContents();
-const { session } = webContents;
-
+const {
+  session
+} = webContents;
 setTimeout(() => {
   const elem = document.querySelector('.landing-title.version-title');
+
   if (elem && elem.innerText.toLowerCase().includes('google chrome')) {
     window.location.reload();
   }
 }, 1000);
 
-const isMutedIcon = element => element.parentElement.parentElement.querySelectorAll('*[data-icon="muted"]').length !== 0;
-
-const isPinnedIcon = element => element.classList.contains('_1EFSv');
-
 window.addEventListener('beforeunload', async () => {
   try {
     session.flushStorageData();
     session.clearStorageData({
-      storages: ['appcache', 'serviceworkers', 'cachestorage', 'websql', 'indexdb'],
+      storages: ['appcache', 'serviceworkers', 'cachestorage', 'websql', 'indexdb']
     });
-
     const registrations = await window.navigator.serviceWorker.getRegistrations();
-
-    registrations.forEach((r) => {
+    registrations.forEach(r => {
       r.unregister();
       console.log('ServiceWorker unregistered');
     });
@@ -33,19 +34,27 @@ window.addEventListener('beforeunload', async () => {
   }
 });
 
-module.exports = (Franz) => {
+module.exports = Franz => {
   const getMessages = function getMessages() {
-    const elements = document.querySelectorAll('.CxUIE, .unread, ._0LqQ, .m61XR .ZKn2B, .VOr2j');
+    const ariaLabels = document.querySelectorAll("span[aria-label]");
     let count = 0;
 
-    for (let i = 0; i < elements.length; i += 1) {
-      try {
-      // originalLog(isMutedIcon(elements[i]), isPinnedIcon(elements[i]));
-        if (!isMutedIcon(elements[i]) && !isPinnedIcon(elements[i])) {
-          count += 1;
+    for (let i = 0; i < ariaLabels.length; i++) {
+      const span = ariaLabels[i];
+      const backgroundColor = window.getComputedStyle(span, null).getPropertyValue("background-color");
+
+      if (backgroundColor == "rgb(0, 175, 156)" || backgroundColor == "rgb(6, 215, 85)") {
+        if (span.ariaLabel == "") {
+          count++;
+          console.log("One item found as marked as unread. Count so far = " + count);
+        } else {
+          const unreadCount = parseInt(span.ariaLabel) || 0;
+
+          if (span.ariaLabel.split(" ")[0] == unreadCount.toString()) {
+            count += unreadCount;
+            console.log("One item found as unread with counter. Count so far = " + count);
+          }
         }
-      } catch (err) {
-        // nope;
       }
     }
 


### PR DESCRIPTION
Change way of determining unread badges from Whatsapp.

Whatsapp uses generated class names, so very often they change and then the recipe stops working.

What I did was to find all spans with aria-label attribute (there are 3 of them: the "your phone is low on battery" close button, the "mark as unread" badge (the badge without a counter) and the threads with unread counters.

The difference between those spans is that only the unread badges has `background-color: var(--unread-marker-background);`.

I could not find a way to read the `var(--unread-marker-background)` from JS, so I get the color from both light and dark theme and using them to find the unread badges.

Finally, I try to parse the contents of the badge (for example: in portuguese, when a badge have (1), the aria-label is "1 mensagem não lida").

So I add that parse + 1 for each "marked as unread" (which have no counter nor aria-label content) and voi-la. A reliable counter that don't depend on Whatsapp class names anymore.