### PR TITLE
update isPinnedIcon check after whatsapp update

### DIFF
--- a/webview.js
+++ b/webview.js
@@ -7,11 +7,9 @@ setTimeout(() => {
   }
 }, 1000);
 
-const isMutedIcon = element =>
-  element.parentElement.parentElement.querySelectorAll('*[data-icon="muted"]')
-    .length !== 0;
+const isMutedIcon = element => element.querySelectorAll('*[data-icon="muted"]').length !== 0;
 
-const isPinnedIcon = element => element.classList.contains('_1EFSv');
+const isPinnedIcon = element => element.querySelectorAll('*[data-icon="pinned"]').length !== 0;
 
 module.exports = (Franz) => {
   const getMessages = function getMessages() {


### PR DESCRIPTION
after whatsapp update the _1EFSv class was not valid anymore for pinned icon. adapted the code to also use the data-icon class and check for pinned.
simplified the isMuted check by removing the not needed parentElement.parentElement tree upwards search